### PR TITLE
Get ECE endpoint properly and add namespace arg

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-version: 1.2.3
+version: 1.2.4
 namespace: expedient
 name: elastic
 readme: README.md

--- a/plugins/module_utils/ece.py
+++ b/plugins/module_utils/ece.py
@@ -109,17 +109,14 @@ class ECE(object):
     repos = self.get_snapshot_repos()
     return next(filter(lambda x: x['repository_name'] == repo_name, repos), None)
 
-  def get_deployment_id(self,deployment_name):
+  def get_deployment_kibana_info(self,deployment_name):
+      deployment_object = ''
       endpoint  = 'deployments'
       deployment_objects = self.send_api_request(endpoint, 'GET')
-      deployment_list = []
       for deployment in deployment_objects['deployments']:
-        deployment_list.append(str(deployment['name']))
-        if deployment['name'] == deployment_name:
-          deployment_object = deployment
-          for resource in deployment['resources']:
-            if resource['ref_id'] == 'main-kibana':
-              deployment_id = resource['id']
-              break
-      return deployment_id
+        if str(deployment['name']).upper() == str(deployment_name).upper():
+          endpoint  = 'deployments/' + deployment['id'] + '/kibana/main-kibana'
+          deployment_object = self.send_api_request(endpoint, 'GET')
+          break
+      return deployment_object
 

--- a/plugins/module_utils/ece.py
+++ b/plugins/module_utils/ece.py
@@ -110,7 +110,7 @@ class ECE(object):
     return next(filter(lambda x: x['repository_name'] == repo_name, repos), None)
 
   def get_deployment_kibana_info(self,deployment_name):
-      deployment_object = ''
+      deployment_object = None
       endpoint  = 'deployments'
       deployment_objects = self.send_api_request(endpoint, 'GET')
       for deployment in deployment_objects['deployments']:

--- a/plugins/module_utils/kibana.py
+++ b/plugins/module_utils/kibana.py
@@ -151,7 +151,7 @@ class Kibana(object):
   
   def check_integration(self, integration_name):
       integration_objects = self.get_integrations()
-      integration_object = ""
+      integration_object = None
       for integration in integration_objects['response']:
         if integration['title'] in integration_name:
           integration_object = integration
@@ -176,10 +176,11 @@ class Kibana(object):
   
   def get_pkg_policy(self,integration_name, agent_policy_id):
     pkg_policy_objects = self.get_all_pkg_policies()
-    pkg_policy_object = ""
+    pkg_policy_object = None
     for pkgPolicy in pkg_policy_objects['items']:
       if pkgPolicy['package']['title'] == integration_name and pkgPolicy['policy_id'] == agent_policy_id:
         pkg_policy_object = pkgPolicy
+        continue
     return pkg_policy_object
   
   def create_pkg_policy(self,pkg_policy_name, pkg_policy_desc, agent_policy_id, integration_object, namespace="default"):
@@ -239,7 +240,7 @@ class Kibana(object):
     return agent_policy_object
 
   def get_agent_policy_byname(self, agent_policy_name):
-    agent_policy_object = ""
+    agent_policy_object = None
     agent_policy_objects = self.get_all_agent_policys()
     for agent_policy in agent_policy_objects['items']:
         if agent_policy['name'] == agent_policy_name:

--- a/plugins/module_utils/kibana.py
+++ b/plugins/module_utils/kibana.py
@@ -182,12 +182,12 @@ class Kibana(object):
         pkg_policy_object = pkgPolicy
     return pkg_policy_object
   
-  def create_pkg_policy(self,pkg_policy_name, pkg_policy_desc, agent_policy_id, integration_object):
+  def create_pkg_policy(self,pkg_policy_name, pkg_policy_desc, agent_policy_id, integration_object, namespace="default"):
     pkg_policy_object = self.get_pkg_policy(integration_object['name'],agent_policy_id)
     if not pkg_policy_object:
       body = {
         "name": pkg_policy_name,
-        "namespace": "default",
+        "namespace": namespace.lower(),
         "description": pkg_policy_desc,
         "enabled": True,
         "policy_id": agent_policy_id,
@@ -215,7 +215,7 @@ class Kibana(object):
     agent_policy_objects = self.send_api_request(endpoint, 'GET')
     return agent_policy_objects
 
-  def create_agent_policy(self, agent_policy_id, agent_policy_name, agent_policy_desc):
+  def create_agent_policy(self, agent_policy_id, agent_policy_name, agent_policy_desc, namespace="default"):
     if agent_policy_id:
       agent_policy_object = self.get_agent_policy_byid(agent_policy_id)
     else:
@@ -224,7 +224,7 @@ class Kibana(object):
     if not agent_policy_object:
       body = {
           "name": agent_policy_name,
-          "namespace": "default",
+          "namespace": namespace.lower(),
           "description": agent_policy_desc,
           "monitoring_enabled": []
       }

--- a/plugins/modules/ece_cluster_info.py
+++ b/plugins/modules/ece_cluster_info.py
@@ -52,15 +52,21 @@ def main():
     #results['deployment_kibana_info'] = deployment_kibana_info
 
     if not deployment_kibana_info:
+      results['deployment_kibana_endpoint'] = None
+      results['deployment_kibana_url'] = None
       results['deployment_kibana_info'] = "No deployment kibana was returned, check your deployment name"
     else:
-      try:
-        results['deployment_kibana_endpoint'] = deployment_kibana_info['info']['metadata']['aliased_endpoint']
-        results['deployment_kibana_url'] = deployment_kibana_info['info']['metadata']['aliased_url']
-      except:
-        results['deployment_kibana_endpoint'] = deployment_kibana_info['info']['metadata']['endpoint']
-        #results['deployment_kibana_service_url'] = deployment_kibana_info['info']['metadata']['service_url']
-        results['deployment_kibana_url'] = deployment_kibana_info['info']['metadata']['aliased_url']
+      results['deployment_kibana_endpoint'] = deployment_kibana_info['info']['metadata'].get('aliased_endpoint') or deployment_kibana_info['info']['metadata']['endpoint']
+      results['deployment_kibana_url'] = deployment_kibana_info['info']['metadata']['aliased_url'] 
+      results['deployment_kibana_info'] = "Deployment kibana was returned sucessfully"
+      
+      #try:
+      #  results['deployment_kibana_endpoint'] = deployment_kibana_info['info']['metadata']['aliased_endpoint']
+      #  results['deployment_kibana_url'] = deployment_kibana_info['info']['metadata']['aliased_url']
+      #except:
+      #  results['deployment_kibana_endpoint'] = deployment_kibana_info['info']['metadata']['endpoint']
+      #  results['deployment_kibana_service_url'] = deployment_kibana_info['info']['metadata']['service_url']
+      #  results['deployment_kibana_url'] = deployment_kibana_info['info']['metadata']['aliased_url']
         
       
     results['changed'] = False

--- a/plugins/modules/ece_cluster_info.py
+++ b/plugins/modules/ece_cluster_info.py
@@ -44,10 +44,25 @@ def main():
         #('alert-type', 'metrics_threshold', ('conditions'))
     
     module = AnsibleModule(argument_spec=module_args, required_if=argument_dependencies, supports_check_mode=True)
+    
+    deployment_name = module.params.get('deployment_name')
+    
     ElasticDeployments = ECE(module)
-    deployment_id = ElasticDeployments.get_deployment_id(module.params.get('deployment_name'))
-    results['deployment_id'] = deployment_id
-   
+    deployment_kibana_info = ElasticDeployments.get_deployment_kibana_info(deployment_name)
+    #results['deployment_kibana_info'] = deployment_kibana_info
+
+    if not deployment_kibana_info:
+      results['deployment_kibana_info'] = "No deployment kibana was returned, check your deployment name"
+    else:
+      try:
+        results['deployment_kibana_endpoint'] = deployment_kibana_info['info']['metadata']['aliased_endpoint']
+        results['deployment_kibana_url'] = deployment_kibana_info['info']['metadata']['aliased_url']
+      except:
+        results['deployment_kibana_endpoint'] = deployment_kibana_info['info']['metadata']['endpoint']
+        #results['deployment_kibana_service_url'] = deployment_kibana_info['info']['metadata']['service_url']
+        results['deployment_kibana_url'] = deployment_kibana_info['info']['metadata']['aliased_url']
+        
+      
     results['changed'] = False
     module.exit_json(**results)
 

--- a/plugins/modules/elastic_agentpolicy.py
+++ b/plugins/modules/elastic_agentpolicy.py
@@ -28,8 +28,6 @@ results = {}
                 
 def main():
 
-    
-
     module_args=dict(    
         host=dict(type='str',required=True),
         port=dict(type='int', default=9243),
@@ -38,7 +36,8 @@ def main():
         verify_ssl_cert=dict(type='bool', default=True),
         agent_policy_name=dict(type='str', required=True),
         agent_policy_desc=dict(type='str', default='None'),
-        state=dict(type='str', default='present')
+        state=dict(type='str', default='present'),
+        namespace=dict(type='str', default='default')
     )
     
     argument_dependencies = []
@@ -54,6 +53,7 @@ def main():
     agent_policy_name = module.params.get('agent_policy_name')
     agent_policy_desc = module.params.get('agent_policy_desc')
     agent_policy_id = module.params.get('agent_policy_id')
+    namespace = module.params.get('namespace')
     
     if module.check_mode:
         results['changed'] = False
@@ -66,8 +66,8 @@ def main():
         results['agent_policy_status'] = "Agent Policy already exists"
         results['changed'] = False
       else:
-        agent_policy_object = kibana.create_agent_policy(agent_policy_id, agent_policy_name, agent_policy_desc)
-        results['agent_policy_status'] = "Creating Agent Policy"
+        agent_policy_object = kibana.create_agent_policy(agent_policy_id, agent_policy_name, agent_policy_desc, namespace)
+        results['agent_policy_status'] = "Agent Policy created"
       results['agent_policy_object'] = agent_policy_object
     else:
       results['agent_policy_status'] = "A valid state was not passed"

--- a/plugins/modules/elastic_agentpolicy_info.py
+++ b/plugins/modules/elastic_agentpolicy_info.py
@@ -64,6 +64,7 @@ def main():
       results['agent_policy_object'] = agent_policy_object
     else:
       results['agent_policy_status'] = "No Agent Policy was returned, check your Agent Policy Name"
+      results['agent_policy_object'] = None
       
     module.exit_json(**results)
 

--- a/plugins/modules/elastic_agentpolicy_info.py
+++ b/plugins/modules/elastic_agentpolicy_info.py
@@ -59,9 +59,12 @@ def main():
     else:
       agent_policy_object = kibana.get_agent_policy_byid(agent_policy_id)
       
-    results['agent_policy_status'] = "Getting Agent Policy"
-    results['agent_policy_object'] = agent_policy_object
-    
+    if agent_policy_object:
+      results['agent_policy_status'] = "Agent Policy Found"
+      results['agent_policy_object'] = agent_policy_object
+    else:
+      results['agent_policy_status'] = "No Agent Policy was returned, check your Agent Policy Name"
+      
     module.exit_json(**results)
 
 if __name__ == "__main__":

--- a/plugins/modules/elastic_endpoint_security.py
+++ b/plugins/modules/elastic_endpoint_security.py
@@ -88,6 +88,7 @@ def main():
         integration_name=dict(type='str', required=True),
         pkg_policy_name=dict(type='str', required=True),
         pkg_policy_desc=dict(type='str'),
+        namespace=dict(type='str', default='default'),
         endpoint_security_antivirus=dict(type='bool', default=True),
         prebuilt_rules_activate=dict(type='bool', default=True),
         state=dict(type='str', default='present')
@@ -106,6 +107,8 @@ def main():
     integration_name = module.params.get('integration_name')
     pkg_policy_name = module.params.get('pkg_policy_name')
     pkg_policy_desc = module.params.get('pkg_policy_desc')
+    pkg_policy_desc = module.params.get('pkg_policy_desc')
+    namespace = module.params.get('namespace')
     
     if module.check_mode:
         results['changed'] = False
@@ -145,7 +148,7 @@ def main():
         results['changed'] = False
       else:
         if module.check_mode == False:    
-          pkg_policy_object = kibana.create_pkg_policy(pkg_policy_name, pkg_policy_desc, agent_policy_id, integration_object)
+          pkg_policy_object = kibana.create_pkg_policy(pkg_policy_name, pkg_policy_desc, agent_policy_id, integration_object, namespace)
           results['pkg_policy_status'] = "No Integration Package found, Package Policy created"
           results['changed'] = True
         else:

--- a/plugins/modules/elastic_pkgpolicy.py
+++ b/plugins/modules/elastic_pkgpolicy.py
@@ -40,7 +40,8 @@ def main():
         integration_name=dict(type='str', required=True),
         pkg_policy_name=dict(type='str', required=True),
         pkg_policy_desc=dict(type='str'),
-        state=dict(type='str', default='present')
+        state=dict(type='str', default='present'),
+        namespace=dict(type='str', default='default')
     )
     argument_dependencies = []
         #('state', 'present', ('enabled', 'alert_type', 'conditions', 'actions')),
@@ -56,6 +57,7 @@ def main():
     pkg_policy_name = module.params.get('pkg_policy_name')
     pkg_policy_desc = module.params.get('pkg_policy_desc')
     integration_name = module.params.get('integration_name')
+    namespace = module.params.get('namespace')
     
     if module.check_mode:
         results['changed'] = False
@@ -93,7 +95,7 @@ def main():
         results['pkg_policy_status'] = "Integration Package found, No package created"
         results['changed'] = False
       else:    
-        pkg_policy_object = kibana.create_pkg_policy(pkg_policy_name, pkg_policy_desc, agent_policy_id, integration_object)
+        pkg_policy_object = kibana.create_pkg_policy(pkg_policy_name, pkg_policy_desc, agent_policy_id, integration_object, namespace)
         results['pkg_policy_status'] = "No Integration Package found, Package Policy created"
       results['pkg_policy_object'] = pkg_policy_object
     else:

--- a/plugins/modules/elastic_pkgpolicy_info.py
+++ b/plugins/modules/elastic_pkgpolicy_info.py
@@ -69,7 +69,7 @@ def main():
       results['changed'] = False
       module.exit_json(**results)
       
-    if module.params.get('integration_name'):
+    if integration_name:
       integration_object = kibana.check_integration(integration_name)
     else:
       results['integration_status'] = "No Integration Name provided to get the integration object"

--- a/plugins/modules/elastic_pkgpolicy_info.py
+++ b/plugins/modules/elastic_pkgpolicy_info.py
@@ -58,9 +58,9 @@ def main():
     kibana = Kibana(module)
 
     if module.params.get('agent_policy_id'):
-      agency_policy_object = kibana.get_agent_policy_byid()
+      agency_policy_object = kibana.get_agent_policy_byid(agent_policy_id)
     else:
-      agency_policy_object = kibana.get_agent_policy_byname()
+      agency_policy_object = kibana.get_agent_policy_byname(agent_policy_name)
     try:
       agent_policy_id = agency_policy_object['id']
       results['agent_policy_status'] = "Agent Policy found."
@@ -70,7 +70,7 @@ def main():
       module.exit_json(**results)
       
     if module.params.get('integration_name'):
-      integration_object = kibana.check_integration(module.params.get('integration_name'))
+      integration_object = kibana.check_integration(integration_name)
     else:
       results['integration_status'] = "No Integration Name provided to get the integration object"
       results['changed'] = False
@@ -81,14 +81,16 @@ def main():
       results['changed'] = False
       module.exit_json(**results)
     
-    pkg_policy_object = kibana.get_pkg_policy(agent_policy_id)
+    pkg_policy_object = kibana.get_pkg_policy(integration_name, agent_policy_id)
     
     if pkg_policy_object:
       results['pkg_policy_status'] = "Integration Package found"
       results['pkg_policy_object'] = pkg_policy_object
     else:
       results['pkg_policy_status'] = "Integration Package NOT found"
-      
+    
+    results['pkg_policy_object'] = pkg_policy_object
+    
     module.exit_json(**results)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Galaxy Version 1.2.4

New Feature:
- Pass namespace for agent policy and package policy.  This applies to baseline creations as well.

Fix:
- Resolved issue getting the kibana endpoint for some deployments by referencing main-kibana object instead of building it from information
- Fixed module to retrieve Integration Package Policy Info
