### PR TITLE
add ability to pass pkg policy version number

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-version: 1.3.7
+version: 1.3.8
 namespace: expedient
 name: elastic
 readme: README.md

--- a/plugins/module_utils/kibana.py
+++ b/plugins/module_utils/kibana.py
@@ -167,21 +167,21 @@ class Kibana(object):
         integration_install = "Cannot proceed with check_mode set to " + self.module.check_mode
       return integration_install
   
-  def check_integration(self, integration_name):
+  def check_integration(self, integration_title):
       integration_objects = self.get_integrations()
-      integration_response = None
+      integration_detail_object = None
       for integration in integration_objects['response']:
-        if integration['title'].upper() in integration_name.upper():
+        if integration['title'].upper() in integration_title.upper():
           if integration['status'] != 'installed':
             integration_install = self.install_integration(integration['name'],integration['version'])
           integration_detail_object = self.get_integration(integration['name'],integration['version'])
-          integration_response = integration_detail_object['response']
           break
-      return integration_response
+      return integration_detail_object
   
   def get_integration(self, integration_name, version):
       endpoint  = 'fleet/epm/packages/' + integration_name + "-" + version
       integration_object = self.send_api_request(endpoint, 'GET')
+      integration_object = integration_object['response']
       return integration_object
     
   # Elastic Integration Package Policy functions

--- a/plugins/modules/elastic_pkgpolicy.py
+++ b/plugins/modules/elastic_pkgpolicy.py
@@ -35,13 +35,16 @@ def main():
         username=dict(type='str', required=True),
         password=dict(type='str', no_log=True, required=True),   
         verify_ssl_cert=dict(type='bool', default=True),
-        agent_policy_name=dict(type='str'),
         agent_policy_id=dict(type='str'),
-        integration_name=dict(type='str', required=True),
+        agent_policy_name=dict(type='str'),
+        integration_title=dict(type='str', required=True),
+        integration_ver=dict(type='str'),
+        integration_name=dict(type='str'),
         pkg_policy_name=dict(type='str', required=True),
         pkg_policy_desc=dict(type='str'),
+        namespace=dict(type='str', default='default'),
         state=dict(type='str', default='present'),
-        namespace=dict(type='str', default='default')
+        integration_settings=dict(type='dict')
     )
     argument_dependencies = []
         #('state', 'present', ('enabled', 'alert_type', 'conditions', 'actions')),
@@ -49,15 +52,19 @@ def main():
     
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True,
                             mutually_exclusive=[('agent_policy_name', 'agent_policy_id')],
-                            required_one_of=[('agent_policy_name', 'agent_policy_id')])
+                            required_one_of=[('agent_policy_name', 'agent_policy_id')],
+                            required_together=[('integration_ver','integration_name')])
     
     state = module.params.get('state')
     agent_policy_name = module.params.get('agent_policy_name')
     agent_policy_id = module.params.get('agent_policy_id')
+    integration_title = module.params.get('integration_title')
+    integration_ver = module.params.get('integration_ver')
+    integration_name = module.params.get('integration_name')
     pkg_policy_name = module.params.get('pkg_policy_name')
     pkg_policy_desc = module.params.get('pkg_policy_desc')
-    integration_name = module.params.get('integration_name')
     namespace = module.params.get('namespace')
+    integration_settings = module.params.get('integration_settings')
     
     if module.check_mode:
         results['changed'] = False
@@ -77,29 +84,60 @@ def main():
       results['changed'] = False
       module.exit_json(**results)
     
-    if module.params.get('integration_name'):
-      integration_object = kibana.check_integration(integration_name)
+    if module.params.get('integration_title'):
+      integration_object = kibana.check_integration(integration_title)
     else:
       results['integration_status'] = "No Integration Name provided to get the integration object"
       results['changed'] = False
       module.exit_json(**results)
     
-    if not integration_object:
-      results['integration_status'] = 'Integration name is not a valid'
+    if ( integration_name and integration_ver and integration_name) and not integration_object:
+      results['integration_status'] = "No integration found, but Integration Name, Version, and Title found"
+      integration_object = {
+        'name': integration_name,
+        'title': integration_title,
+        'version': integration_ver
+      }
+    elif not integration_object and not ( integration_name and integration_ver and integration_name):
+      results['integration_status'] = 'Integration Title is not valid and integration name and integration version are not found'
       results['changed'] = False
-      module.exit_json(**results)
+      module.exit_json(**results) 
     
     if state == "present":
-      pkg_policy_object = kibana.get_pkg_policy(integration_name,agent_policy_id)
+      pkg_policy_object = kibana.get_pkg_policy(integration_title,agent_policy_id)
       if pkg_policy_object:
         results['pkg_policy_status'] = "Integration Package found, No package created"
         results['changed'] = False
       else:
-        pkg_policy_object = kibana.create_pkg_policy(pkg_policy_name, pkg_policy_desc, agent_policy_id, integration_object['response'], namespace)
+        pkg_policy_object = kibana.create_pkg_policy(pkg_policy_name, pkg_policy_desc, agent_policy_id, integration_object, namespace)
         results['pkg_policy_status'] = "No Integration Package found, Package Policy created"
       results['pkg_policy_object'] = pkg_policy_object
     else:
       results['pkg_policy_object'] = "A valid state was not passed"
+
+    if integration_settings:
+      if not 'package' in pkg_policy_object:
+          pkg_policy_object = pkg_policy_object['item']
+      pkg_policy_object_id = pkg_policy_object['id']  
+      
+      integration_settings_json = integration_settings
+      results['passed_integration_settings'] = integration_settings_json
+      if not 'name' in integration_settings_json:
+        integration_settings_json['name'] = pkg_policy_object['name']
+      if not 'policy_id' in integration_settings_json:
+        integration_settings_json['policy_id'] = pkg_policy_object['policy_id']
+      if not 'enabled' in integration_settings_json:
+        integration_settings_json['enabled'] = pkg_policy_object['enabled']
+      if not 'namespace' in integration_settings_json:
+        integration_settings_json['namespace'] = pkg_policy_object['namespace']
+      if not 'package' in integration_settings_json:
+        integration_settings_json['package'] = pkg_policy_object['package']
+      if not 'output_id' in integration_settings_json:
+        integration_settings_json['output_id'] = pkg_policy_object['output_id']
+      if not 'inputs' in integration_settings_json:
+        integration_settings_json['inputs'] = pkg_policy_object['inputs']
+      pkg_policy_info = kibana.update_pkg_policy(pkg_policy_object_id,integration_settings_json)
+
       
     module.exit_json(**results)
 

--- a/plugins/modules/elastic_pkgpolicy.py
+++ b/plugins/modules/elastic_pkgpolicy.py
@@ -122,20 +122,10 @@ def main():
       
       integration_settings_json = integration_settings
       results['passed_integration_settings'] = integration_settings_json
-      if not 'name' in integration_settings_json:
-        integration_settings_json['name'] = pkg_policy_object['name']
-      if not 'policy_id' in integration_settings_json:
-        integration_settings_json['policy_id'] = pkg_policy_object['policy_id']
-      if not 'enabled' in integration_settings_json:
-        integration_settings_json['enabled'] = pkg_policy_object['enabled']
-      if not 'namespace' in integration_settings_json:
-        integration_settings_json['namespace'] = pkg_policy_object['namespace']
-      if not 'package' in integration_settings_json:
-        integration_settings_json['package'] = pkg_policy_object['package']
-      if not 'output_id' in integration_settings_json:
-        integration_settings_json['output_id'] = pkg_policy_object['output_id']
-      if not 'inputs' in integration_settings_json:
-        integration_settings_json['inputs'] = pkg_policy_object['inputs']
+      for current_setting in ['name', 'policy_id', 'enabled', 'namespace', 'package', 'output_id', 'inputs']:
+        if current_setting not in integration_settings_json:
+          integration_settings_json[current_setting] = pkg_policy_object[current_setting]
+
       pkg_policy_info = kibana.update_pkg_policy(pkg_policy_object_id,integration_settings_json)
 
       


### PR DESCRIPTION
Bug Fix:
- The elastic REST API doesn't always return all the available integrations. This was used to validate it exists before trying to create a package policy using an integration.  This change allows the integration title, name, and version to bypass this check.

Features:
- Removed need for separate Endpoint Security module to accommodate pkg policy specific needs by creating a detection rule activation module and updating the pkg policy module to be able to take integration settings.  