### PR TITLE
Fix max return objects

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-version: 2.0.2
+version: 2.0.3
 namespace: expedient
 name: elastic
 readme: README.md

--- a/plugins/module_utils/kibana.py
+++ b/plugins/module_utils/kibana.py
@@ -187,7 +187,8 @@ class Kibana(object):
   # Elastic Integration Package Policy functions
 
   def get_all_pkg_policies(self):
-      endpoint  = 'fleet/package_policies'
+      perPage = "500"
+      endpoint  = 'fleet/package_policies?perPage='+ perPage
       pkgpolicy_objects = self.send_api_request(endpoint, 'GET')
       return pkgpolicy_objects
   
@@ -321,7 +322,8 @@ class Kibana(object):
 # Elastic Agent Policy functions
 
   def get_all_agent_policys(self):
-    endpoint  = 'fleet/agent_policies'
+    perPage = "500"
+    endpoint  = 'fleet/agent_policies?perPage='+ perPage
     agent_policy_objects = self.send_api_request(endpoint, 'GET')
     return agent_policy_objects
 


### PR DESCRIPTION
Bug Fix:
- Updating max returned objects to 500 from 20. This could cause issues if there are many agent policies
- Improved method of applying Default Settings for Pkg Policy. It seems Elastic has improved REST API to properly create Pkg Polices and it is possible to not have to apply all default settings.