### PR TITLE
Kibana api update

### DIFF
--- a/docs/expedient.elastic.kibana_alert_module.rst
+++ b/docs/expedient.elastic.kibana_alert_module.rst
@@ -20,6 +20,9 @@ Synopsis
 - This module creates or deletes alerts in kibana
 - currently supports threshold alerts
 
+Note: Kibana has updated their API. One of the major changes is that "alerts" are now called "rules".
+This can cause some confusion when using the Kibana API documentation while working on this module.
+For that reason, "alert" and "rule" are synonymous in this module.
 
 
 Requirements

--- a/plugins/module_utils/kibana.py
+++ b/plugins/module_utils/kibana.py
@@ -91,22 +91,22 @@ class Kibana(object):
         'alertOnNoData': alert_on_no_data,
         'sourceId': 'default' #entirely unclear what this does but it appears to be a static value so hard-coding for now
       },
-      'consumer': self.consumer,
       'schedule': {
-        'interval': self.check_every
+        'interval': self.module.params.get('check_every')
       },
       'actions': self.format_alert_actions(),
-      'tags': self.tags,
-      'name': self.alert_name,
-      'enabled': self.enabled
+      'tags': self.module.params.get('tags'),
+      'name': self.module.params.get('alert_name')
     }
-    if self.filter:
-      data['params']['filterQueryText'] = self.filter
-      data['params']['filterQuery'] = self.filter_query
+    if self.module.params.get('filter'):
+      data['params']['filterQueryText'] = self.module.params.get('filter')
+      data['params']['filterQuery'] = self.module.params.get('filter_query')
     if self.group_by:
-        data['params']['groupBy'] = self.group_by
+        data['params']['groupBy'] = self.module.params.get('group_by')
     if method.upper() == "POST":
       data['rule_type_id'] = lookups.alert_type_lookup[alert_type]
+      data['consumer'] = self.module.params.get('consumer')
+      data['enabled']= self.module.params.get('enabled')
     result = self.send_api_request(endpoint, method, data=data)
     return result
   

--- a/plugins/module_utils/kibana.py
+++ b/plugins/module_utils/kibana.py
@@ -83,6 +83,7 @@ class Kibana(object):
     notify_when = self.module.params.get('notify_on')
     alert_on_no_data = self.module.params.get('alert_on_no_data')
     alert_type = self.module.params.get('alert_type')
+    group_by = self.module.params.get('group_by')
 
     data = {
       'notify_when': lookups.notify_lookup[notify_when],
@@ -101,7 +102,7 @@ class Kibana(object):
     if self.module.params.get('filter'):
       data['params']['filterQueryText'] = self.module.params.get('filter')
       data['params']['filterQuery'] = self.module.params.get('filter_query')
-    if self.group_by:
+    if group_by:
         data['params']['groupBy'] = self.module.params.get('group_by')
     if method.upper() == "POST":
       data['rule_type_id'] = lookups.alert_type_lookup[alert_type]

--- a/plugins/module_utils/kibana.py
+++ b/plugins/module_utils/kibana.py
@@ -16,6 +16,7 @@ from ansible.module_utils.urls import open_url, urllib_error
 from json import loads, dumps
 from urllib.error import HTTPError
 import urllib.parse
+import lookups
 
 class Kibana(object):
   def __init__(self, module):

--- a/plugins/module_utils/lookups.py
+++ b/plugins/module_utils/lookups.py
@@ -1,0 +1,40 @@
+time_unit_lookup = {
+  'second': 's',
+  'seconds': 's',
+  'minute': 'm',
+  'minutes': 'm',
+  'hour': 'h',
+  'hours': 'h',
+  'day': 'd',
+  'days': 'd',
+}
+
+alert_type_lookup = {
+  'metrics_threshold': 'metrics.alert.threshold'
+}
+
+action_type_lookup = {
+  'email': '.email',
+  'index': '.index',
+  'webhook': '.webhook'
+}
+
+# Need to get warning thresholds added here too
+action_group_lookup = {
+  'alert': 'metrics.threshold.fired',
+  'recovered': 'metrics.threshold.recovered'
+}
+
+action_param_type_lookup = {
+  'index': 'documents',
+  'webhook': 'body'
+}
+
+state_lookup = {
+  'above': '>',
+  'below': '<'
+}
+
+notify_lookup = {
+  'status_change': 'onActionGroupChange'
+}

--- a/plugins/modules/kibana_alert.py
+++ b/plugins/modules/kibana_alert.py
@@ -122,57 +122,17 @@ extends_documentation_fragment:
 
 try:
   from ansible_collections.expedient.elastic.plugins.module_utils.kibana import Kibana
+  import ansible_collections.expedient.elastic.plugins.module_utils.lookups
 except:
   import sys
   import os
   util_path = new_path = f'{os.getcwd()}/plugins/module_utils'
   sys.path.append(util_path)
   from kibana import Kibana
+  import lookups
 
 from ansible.module_utils.basic import AnsibleModule
 from json import dumps
-
-time_unit_lookup = {
-  'second': 's',
-  'seconds': 's',
-  'minute': 'm',
-  'minutes': 'm',
-  'hour': 'h',
-  'hours': 'h',
-  'day': 'd',
-  'days': 'd',
-}
-
-alert_type_lookup = {
-  'metrics_threshold': 'metrics.alert.threshold'
-}
-
-action_type_lookup = {
-  'email': '.email',
-  'index': '.index',
-  'webhook': '.webhook'
-}
-
-# Need to get warning thresholds added here too
-action_group_lookup = {
-  'alert': 'metrics.threshold.fired',
-  'recovered': 'metrics.threshold.recovered'
-}
-
-action_param_type_lookup = {
-  'index': 'documents',
-  'webhook': 'body'
-}
-
-state_lookup = {
-  'above': '>',
-  'below': '<'
-}
-
-notify_lookup = {
-  'status_change': 'onActionGroupChange'
-}
-
 
 class KibanaAlert(Kibana):
   def __init__(self, module):

--- a/plugins/modules/kibana_alert.py
+++ b/plugins/modules/kibana_alert.py
@@ -212,7 +212,7 @@ def main():
     if kibana_alert.alert:
       results['msg'] = f'alert named {kibana_alert.alert_name} exists, and will be updated'
       if not module.check_mode:
-        update_result = kibana_alert.ensure_alert(method='PUT', alert_id=alert['id'])
+        update_result = kibana_alert.ensure_alert(alert_id=alert['id'])
         if update_result is not None:
           results['msg'] = f'alert named {kibana_alert.alert_name} updated'
           results['changed'] = True
@@ -224,7 +224,7 @@ def main():
     results['msg'] = f'alert named {module.params.get("alert_name")} will be created'
     if not module.check_mode:
       notify_on = lookups.notify_lookup[module.params.get("notify_on")]
-      results['alert'] = kibana_alert.ensure_alert("POST")
+      results['alert'] = kibana_alert.ensure_alert()
       results['msg'] = f'alert named {module.params.get("alert_name")} created'
     module.exit_json(**results)
   if state == 'absent':

--- a/plugins/modules/kibana_alert.py
+++ b/plugins/modules/kibana_alert.py
@@ -216,11 +216,11 @@ class KibanaAlert(Kibana):
           formatted_condition['metric'] = condition['field']
         formatted_conditions.append(formatted_condition)
     return formatted_conditions
+])]
 
   def format_actions(self):
     actions = self.module.params.get('actions')
     formatted_actions = [{
-      'actionTypeId': action_type_lookup[action['action_type']],
       'group': action_group_lookup[action['run_when']],
       'params': {
         action_param_type_lookup[action['action_type']]: [action['body']] if action['body'] else dumps(action['body_json'], indent=2)

--- a/plugins/modules/kibana_alert.py
+++ b/plugins/modules/kibana_alert.py
@@ -230,17 +230,17 @@ class KibanaAlert(Kibana):
     return formatted_actions
 
   def create_alert(self):
-    endpoint = 'alerts/alert'
+    endpoint = 'alerting/rule'
     criteria = self.format_conditions()
     data = {
-      'notifyWhen': notify_lookup[self.notify_when],
+      'notify_when': notify_lookup[self.notify_when],
       'params': {
         'criteria': criteria,
         'alertOnNoData': self.alert_on_no_data,
         'sourceId': 'default' #entirely unclear what this does but it appears to be a static value so hard-coding for now
       },
       'consumer': self.consumer,
-      'alertTypeId': alert_type_lookup[self.alert_type],
+      'rule_type_id': alert_type_lookup[self.alert_type],
       'schedule': {
         'interval': self.check_every
       },

--- a/plugins/modules/kibana_alert.py
+++ b/plugins/modules/kibana_alert.py
@@ -159,100 +159,6 @@ class KibanaAlert(Kibana):
     head = time_string[:len(time_string) - len(tail)]
     return head, tail
 
-  # This will defnitely need changes as we expand out functionality of the alert module, currently really only works with metrcis thresholds
-  def format_conditions(self):
-    conditions = self.module.params.get('conditions')
-    formatted_conditions = []
-    if self.alert_type == 'metrics_threshold':
-      for condition in conditions:
-        formatted_condition = {
-          'aggType': condition['when'],
-          'comparator': state_lookup[condition['state']],
-          'threshold': [condition['threshold']] if condition['threshold'] != 0.0 else [int(condition['threshold'])],
-          'timeSize': condition['time_period'],
-          'timeUnit': time_unit_lookup[condition['time_unit']],
-        }
-        if condition['field'] is not None:
-          formatted_condition['metric'] = condition['field']
-        formatted_conditions.append(formatted_condition)
-    return formatted_conditions
-
-  def format_actions(self):
-    actions = self.module.params.get('actions')
-    formatted_actions = [{
-      'group': action_group_lookup[action['run_when']],
-      'params': {
-        action_param_type_lookup[action['action_type']]: [action['body']] if action['body'] else dumps(action['body_json'], indent=2)
-      },
-      'id': self.get_alert_connector_by_name(action['connector'])['id'] ## need to actually implement this
-    } for action in actions]
-    return formatted_actions
-
-  def create_alert(self):
-    endpoint = 'alerting/rule'
-    criteria = self.format_conditions()
-    data = {
-      'notify_when': notify_lookup[self.notify_when],
-      'params': {
-        'criteria': criteria,
-        'alertOnNoData': self.alert_on_no_data,
-        'sourceId': 'default' #entirely unclear what this does but it appears to be a static value so hard-coding for now
-      },
-      'consumer': self.consumer,
-      'rule_type_id': alert_type_lookup[self.alert_type],
-      'schedule': {
-        'interval': self.check_every
-      },
-      'actions': self.format_actions(),
-      'tags': self.tags,
-      'name': self.alert_name,
-      'enabled': self.enabled
-    }
-    if self.filter:
-      data['params']['filterQueryText'] = self.filter
-      data['params']['filterQuery'] = self.filter_query
-    if self.group_by:
-        data['params']['groupBy'] = self.group_by
-    result = self.send_api_request(endpoint, 'POST', data=data)
-    return result
-
-  def delete_alert(self):
-    endpoint = f'alerting/rule/{self.alert["id"]}'
-    return self.send_api_request(endpoint, 'DELETE')
-
-  def update_alert(self):
-    endpoint = f'alerting/rule/{self.alert["id"]}'
-    criteria = self.format_conditions()
-    data = {
-      'notify_when': notify_lookup[self.notify_when],
-      'params': {
-        'criteria': criteria,
-        'alertOnNoData': self.alert_on_no_data,
-        'sourceId': 'default'  # if you don't include this, the API will throw 400 error
-      },
-      'schedule': {
-        'interval': self.check_every
-      },
-      'actions': self.format_actions(),
-      'tags': self.tags,
-      'name': self.alert_name,
-    }
-    if self.filter:
-      data['params']['filterQueryText'] = self.filter
-      data['params']['filterQuery'] = self.filter_query
-    if self.group_by:
-        data['params']['groupBy'] = self.group_by
-    # Don't make changes if all values match existing values, and no new keys are added
-    if (not {key: data[key] for key, value in self.alert.items()
-             if key in data and data[key] != value}
-        and not set(data.keys()) - set(self.alert.keys())):
-      return None
-    result = self.send_api_request(endpoint, 'PUT', data=data)
-    return result
-
-
-
-
 def main():
   module_args=dict(
     host=dict(type='str', required=True),
@@ -301,11 +207,12 @@ def main():
   module = AnsibleModule(argument_spec=module_args, required_if=argument_dependencies, supports_check_mode=True)
   state = module.params.get('state')
   kibana_alert = KibanaAlert(module)
+  alert = kibana_alert.get_alert_by_name(module.params.get('alert_name'))
   if state == 'present':
     if kibana_alert.alert:
       results['msg'] = f'alert named {kibana_alert.alert_name} exists, and will be updated'
       if not module.check_mode:
-        update_result = kibana_alert.update_alert()
+        update_result = kibana_alert.ensure_alert(method='PUT', alert_id=alert['id'])
         if update_result is not None:
           results['msg'] = f'alert named {kibana_alert.alert_name} updated'
           results['changed'] = True
@@ -316,7 +223,8 @@ def main():
     results['changed'] = True
     results['msg'] = f'alert named {module.params.get("alert_name")} will be created'
     if not module.check_mode:
-      results['alert'] = kibana_alert.create_alert()
+      notify_on = lookups.notify_lookup[module.params.get("notify_on")]
+      results['alert'] = kibana_alert.ensure_alert("POST")
       results['msg'] = f'alert named {module.params.get("alert_name")} created'
     module.exit_json(**results)
   if state == 'absent':
@@ -326,7 +234,7 @@ def main():
     results['changed'] = True
     results['msg'] = f'alert named {module.params.get("alert_name")} will be deleted'
     if not module.check_mode:
-      kibana_alert.delete_alert()
+      kibana_alert.delete_alert(alert_id=alert['id'])
     module.exit_json(**results)
 
 if __name__ == '__main__':

--- a/plugins/modules/kibana_alert.py
+++ b/plugins/modules/kibana_alert.py
@@ -257,7 +257,7 @@ class KibanaAlert(Kibana):
     return result
 
   def delete_alert(self):
-    endpoint = f'alerts/alert/{self.alert["id"]}'
+    endpoint = f'alerting/rule/{self.alert["id"]}'
     return self.send_api_request(endpoint, 'DELETE')
 
   def update_alert(self):

--- a/plugins/modules/kibana_alert.py
+++ b/plugins/modules/kibana_alert.py
@@ -216,7 +216,6 @@ class KibanaAlert(Kibana):
           formatted_condition['metric'] = condition['field']
         formatted_conditions.append(formatted_condition)
     return formatted_conditions
-])]
 
   def format_actions(self):
     actions = self.module.params.get('actions')

--- a/plugins/modules/kibana_alert.py
+++ b/plugins/modules/kibana_alert.py
@@ -309,7 +309,7 @@ def main():
     check_every=dict(type='str', default='1m'),
     notify_on=dict(type='str', default='status_change', choices=['status_change']),
     conditions=dict(type='list', elements='dict', options=dict(
-      when=dict(type='str', required=True, choices=['max', 'min', 'avg', 'cardnality', 'rate', 'count', 'sum', '95th_percentile', '99th_percentile']),
+      when=dict(type='str', required=True, choices=['max', 'min', 'avg', 'cardinality', 'rate', 'count', 'sum', '95th_percentile', '99th_percentile']),
       field=dict(type='str', required=False),
       state=dict(type='str', required=True),
       threshold=dict(type='float', required=True),

--- a/plugins/modules/kibana_alert.py
+++ b/plugins/modules/kibana_alert.py
@@ -261,10 +261,10 @@ class KibanaAlert(Kibana):
     return self.send_api_request(endpoint, 'DELETE')
 
   def update_alert(self):
-    endpoint = f'alerts/alert/{self.alert["id"]}'
+    endpoint = f'alerting/rule/{self.alert["id"]}'
     criteria = self.format_conditions()
     data = {
-      'notifyWhen': notify_lookup[self.notify_when],
+      'notify_when': notify_lookup[self.notify_when],
       'params': {
         'criteria': criteria,
         'alertOnNoData': self.alert_on_no_data,


### PR DESCRIPTION
The API that we're currently using for the kibana_alert module is deprecated. This PR contains changes to update endpoints and parameters to match the current API. 

Some things of note:

- The endpoints for create, update and delete functions have changed.
- The naming conventions for some parameters have changed from camel case to snake case.
- "alerts" are now called "rules" in Kibana-land. Added a note to the module docs to help with confusion.