### PR TITLE
fix_pkg_policy_failure

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-version: 2.0.3
+version: 2.1.2
 namespace: expedient
 name: elastic
 readme: README.md

--- a/plugins/module_utils/kibana.py
+++ b/plugins/module_utils/kibana.py
@@ -206,6 +206,17 @@ class Kibana(object):
         body.pop('updated_at')
       if 'updated_by' in body:
         body.pop('updated_by')
+      input_no = 0
+      for input in body['inputs']:
+        if 'streams' in input:
+          streams_no = 0
+          for stream in input['streams']:
+            if 'id' in stream:
+              body['inputs'][input_no]['streams'][streams_no].pop('id')
+            if 'compiled_stream' in stream:
+              body['inputs'][input_no]['streams'][streams_no].pop('compiled_stream')
+            streams_no = streams_no + 1
+        input_no = input_no + 1
       if not self.module.check_mode:
         endpoint = "fleet/package_policies/" + pkgpolicy_id
         pkg_policy_update = self.send_api_request(endpoint, 'PUT', data=body)


### PR DESCRIPTION
Bug Fix:
- My bad...I didn't test creating the Operations CTRL policy creation because I had no reason to think they would fail...they did because of objects that can't be applied as part of the update. The fix looks for them and removes them.