### PR TITLE
Uptime monitor status alert 

### DIFF
--- a/plugins/module_utils/kibana.py
+++ b/plugins/module_utils/kibana.py
@@ -160,7 +160,8 @@ class Kibana(object):
   def format_alert_availability(self):
     availability = self.module.params.get('availability')
     formatted_availability = {}
-    if self.alert_type == 'uptime_monitor_status':
+    alert_type = self.module.params.get('alert_type')
+    if alert_type == 'uptime_monitor_status':
       formatted_availability = {
         'range': availability['range'],
         'rangeUnit': lookups.time_unit_lookup[availability['rangeUnit']],
@@ -193,7 +194,13 @@ class Kibana(object):
         'timerangeUnit': lookups.time_unit_lookup[self.module.params.get('timerangeUnit')]
       }
 
-      return formatted_params
+    if self.module.params.get('filter'):
+      formatted_params['filterQueryText'] = self.module.params.get('filter')
+      formatted_params['filterQuery'] = self.module.params.get('filter_query')
+    if self.module.params.get('group_by'):
+      formatted_params['groupBy'] = self.module.params.get('group_by')
+
+    return formatted_params
   
   # Elastic Security Rules functions
 

--- a/plugins/module_utils/lookups.py
+++ b/plugins/module_utils/lookups.py
@@ -10,7 +10,8 @@ time_unit_lookup = {
 }
 
 alert_type_lookup = {
-  'metrics_threshold': 'metrics.alert.threshold'
+  'metrics_threshold': 'metrics.alert.threshold',
+  'uptime_monitor_status': 'xpack.uptime.alerts.monitorStatus'
 }
 
 action_type_lookup = {
@@ -22,7 +23,8 @@ action_type_lookup = {
 # Need to get warning thresholds added here too
 action_group_lookup = {
   'alert': 'metrics.threshold.fired',
-  'recovered': 'metrics.threshold.recovered'
+  'recovered': 'metrics.threshold.recovered',
+  'uptime_down_monitor': "xpack.uptime.alerts.actionGroups.monitorStatus"
 }
 
 action_param_type_lookup = {

--- a/plugins/modules/kibana_alert.py
+++ b/plugins/modules/kibana_alert.py
@@ -169,7 +169,7 @@ def main():
     state=dict(type='str', default='present', choices=['present', 'absent']),
     alert_name=dict(type='str', required=True),
     enabled=dict(type='bool', default=True),
-    alert_type=dict(type='str', choices=['metrics_threshold']), #more types will be added as we gain the ability to support them
+    alert_type=dict(type='str', choices=['metrics_threshold', 'uptime_monitor_status']), #more types will be added as we gain the ability to support them
     tags=dict(type='list', elements='str', default=[]),
     check_every=dict(type='str', default='1m'),
     notify_on=dict(type='str', default='status_change', choices=['status_change']),
@@ -182,13 +182,24 @@ def main():
       time_period=dict(type='int', default=5),
       time_unit=dict(type='str', default='minute', choices=['second', 'seconds', 'minute', 'minutes', 'hour', 'hours', 'day', 'days']),
     )),
+    availability=dict(type='dict', options=dict(
+      range=dict(type='int', default=30),
+      rangeUnit=dict(type='str', default='minute', choices=['second', 'seconds', 'minute', 'minutes', 'hour', 'hours', 'day', 'days']),
+      threshold=dict(type='str', default='99')
+    )),
+    numTimes=dict(type='int', default=5),
+    search=dict(type='str', default=''),
+    shouldCheckAvailability=dict(type='bool', default=True),
+    shouldCheckStatus=dict(type='bool', default=True),
+    timerangeCount=dict(type=int, default=15),
+    timerangeUnit=dict(type='str', default='minute', choices=['second', 'seconds', 'minute', 'minutes', 'hour', 'hours', 'day', 'days']),
     filter=dict(type='str'),
     filter_query=dict(type='str'),
     alert_on_no_data=dict(type='bool', default=False),
     group_by=dict(type='list', elements='str', required=False),
     actions=dict(type='list', elements='dict', options=dict(
       action_type=dict(type='str', required=True, choices=['email', 'index', 'webhook']), #Only supporting these types for now, if we need more options later we can deal with them as-needed
-      run_when=dict(type='str', default='alert', choices=['alert', 'warning', 'recovered']),
+      run_when=dict(type='str', default='alert', choices=['alert', 'warning', 'recovered','uptime_down_monitor']),
       connector=dict(type='str', required=True),
       body=dict(type='str', required=False),
       body_json=dict(type='dict', required=False)
@@ -198,8 +209,9 @@ def main():
 
   # https://docs.ansible.com/ansible/latest/dev_guide/developing_program_flow_modules.html#argument-spec-dependencies
   argument_dependencies = [
-    ('state', 'present', ('enabled', 'alert_type', 'conditions', 'actions')),
-    ('alert-type', 'metrics_threshold', ('conditions'))
+    ('state', 'present', ('enabled', 'alert_type', 'actions')),
+    ('alert-type', 'metrics_threshold', ('conditions')),
+    ('alert-type', 'uptime_monitor_status', ('enabled','alert_type','actions','availability','numTimes', 'search', 'shouldCheckAvailability', 'shouldCheckStatus', 'timerangeCount', 'timerangeUnit'))
   ]
 
   results = {'changed': False}

--- a/plugins/modules/kibana_alert.py
+++ b/plugins/modules/kibana_alert.py
@@ -85,6 +85,46 @@ options:
       - only used for metrics threshold alerts.
       - see examples for details
     type: dict
+  availability:
+    description:
+      - dictionary defining the availability of the alert
+      - only used for uptime monitor status alerts
+      - see examples for details
+    type: dict
+  numTimes:
+    description:
+      - The number of times a monitor can go down within a specified 
+        time range (timerangeCount, timerangeUnit) before an alert is 
+        triggered.
+      default: 5
+      type: int
+  search:
+    description:
+      - The default term that appears in the filter search bar
+        when manually editing the rule.
+    type: str
+    default: ""
+  shouldcheckAvailability:
+    description:
+      - whether or not the uptime monitor should check availability
+    type: bool
+    default: True
+  shouldCheckStatus:
+    description:
+      - whether or not the uptime monitor should check status
+    type: bool
+    default: True
+  timerangeCount:
+    description:
+      - The number of timerangeUnits in which a monitor can go down
+        in which a monitor can go down up to numTimes.
+    default: 15
+    type: int
+  timerangeUnit:
+    description:
+      - The unit coinciding with timerangeCount (minute, day, week, etc.)
+    default: "minute"
+    choices: ['second', 'seconds', 'minute', 'minutes', 'hour', 'hours', 'day', 'days']
   filter:
     description:
       - kql filter to apply to the conditions

--- a/plugins/modules/kibana_alert.py
+++ b/plugins/modules/kibana_alert.py
@@ -235,7 +235,6 @@ def main():
     results['changed'] = True
     results['msg'] = f'alert named {module.params.get("alert_name")} will be created'
     if not module.check_mode:
-      notify_on = lookups.notify_lookup[module.params.get("notify_on")]
       results['alert'] = kibana_alert.ensure_alert()
       results['msg'] = f'alert named {module.params.get("alert_name")} created'
     module.exit_json(**results)


### PR DESCRIPTION
Add uptime monitor status alert type to kibana_alert module. 

This PR will add new parameters to the kibana_alert module, as well as new functions in module_utils/kibana.py to better handle the differences between alert types when calling ensure_alert()