### PR TITLE
Add kibana_fleet_host module

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-version: 2.2.2
+version: 2.3.0
 namespace: expedient
 name: elastic
 readme: README.md

--- a/plugins/module_utils/kibana.py
+++ b/plugins/module_utils/kibana.py
@@ -553,6 +553,11 @@ class Kibana(object):
       page_number = page_number + 1
     return agent_list_result
 
+  def get_fleet_server_hosts(self):
+    endpoint = 'fleet/settings'
+    result = self.send_api_request(endpoint, 'GET')
+    return result['item']['fleet_server_hosts']
+
   def set_fleet_server_host(self, host):
     endpoint = 'fleet/settings'
     headers = {'kbn-xsrf': True}

--- a/plugins/module_utils/kibana.py
+++ b/plugins/module_utils/kibana.py
@@ -572,6 +572,13 @@ class Kibana(object):
     result = self.send_api_request(endpoint, 'PUT', headers=headers, data=body_json)
     return result
 
+  def get_fleet_elasticsearch_hosts(self):
+    endpoint = 'fleet/outputs'
+    result = self.send_api_request(endpoint, 'GET')
+    for item in result['items']:
+      if item['id'] == "fleet-default-output" and item['type'] == 'elasticsearch':
+        return item['hosts']
+
   def set_fleet_elasticsearch_host(self, host):
     endpoint = 'fleet/outputs/fleet-default-output'
     body = {

--- a/plugins/module_utils/kibana.py
+++ b/plugins/module_utils/kibana.py
@@ -557,13 +557,11 @@ class Kibana(object):
     result = self.send_api_request(endpoint, 'GET')
     return result['item']['fleet_server_hosts']
 
-  def set_fleet_server_host(self, host):
+  def set_fleet_server_hosts(self, hosts: list):
     endpoint = 'fleet/settings'
     headers = {'kbn-xsrf': True}
     body = {
-        'fleet_server_hosts': [
-          host
-        ]
+        'fleet_server_hosts': hosts
       }
 
     body_json = dumps(body)
@@ -578,12 +576,10 @@ class Kibana(object):
       if item['id'] == "fleet-default-output" and item['type'] == 'elasticsearch':
         return item['hosts']
 
-  def set_fleet_elasticsearch_host(self, host):
+  def set_fleet_elasticsearch_hosts(self, hosts: list):
     endpoint = 'fleet/outputs/fleet-default-output'
     body = {
-      'hosts': [
-        host
-      ]
+      'hosts': hosts
     }
 
     body_json = dumps(body)

--- a/plugins/module_utils/kibana.py
+++ b/plugins/module_utils/kibana.py
@@ -39,7 +39,6 @@ class Kibana(object):
 
   def send_api_request(self, endpoint, method, data=None, headers={}):
     url = f'https://{self.host}:{self.port}/api/{endpoint}'
-    headers = {}
     payload = None
     if data:
       headers['Content-Type'] = 'application/json'

--- a/plugins/module_utils/kibana.py
+++ b/plugins/module_utils/kibana.py
@@ -37,7 +37,7 @@ class Kibana(object):
     self.version = None # this is a hack to make it so that we can run the first request to get the clutser version without erroring out
     self.version = self.get_cluster_version()
 
-  def send_api_request(self, endpoint, method, data=None):
+  def send_api_request(self, endpoint, method, data=None, headers={}):
     url = f'https://{self.host}:{self.port}/api/{endpoint}'
     headers = {}
     payload = None

--- a/plugins/module_utils/kibana.py
+++ b/plugins/module_utils/kibana.py
@@ -552,3 +552,30 @@ class Kibana(object):
         agent_no = agent_no + 1
       page_number = page_number + 1
     return agent_list_result
+
+  def set_fleet_server_host(self, host):
+    endpoint = 'fleet/settings'
+    headers = {'kbn-xsrf': True}
+    body = {
+        'fleet_server_hosts': [
+          host
+        ]
+      }
+
+    body_json = dumps(body)
+
+    result = self.send_api_request(endpoint, 'PUT', headers=headers, data=body_json)
+    return result
+
+  def set_fleet_elasticsearch_host(self, host):
+    endpoint = 'fleet/outputs/fleet-default-output'
+    body = {
+      'hosts': [
+        host
+      ]
+    }
+
+    body_json = dumps(body)
+
+    result = self.send_api_request(endpoint, 'PUT', data=body_json)
+    return result

--- a/plugins/modules/kibana_fleet_host.py
+++ b/plugins/modules/kibana_fleet_host.py
@@ -57,18 +57,29 @@ options:
         description:
             - Whether or not to verify SSL cert on API requests
         type: bool
-    url:
+    urls:
         description:
-            - The url that you want to apply as a fleet server host or an elasticsearch host
-        type: str
+            - List of urls that you want to apply as a fleet server host or an elasticsearch host
+        type: list
+        element type: str
     url_type:
         description:
             - The url type that you want to set for the fleet
             - 'server' sets the fleet server host
             - 'elasticsearch' sets the fleet elasticsearch host
         options:
-            - server
+            - fleet_server
             - elasticsearch
+    action:
+        description:
+            - The action that you want the module to take against the fleet server
+            - Add: Add the provided urls to the fleet
+            - Remove: Remove the provided urls from the fleet
+            - Overwrite: Replace the urls in the fleet with the provided urls
+        options:
+            - Add
+            - Remove
+            - Overwrite
 
 extends_documentation_fragment:
   - expedient.elastic.elastic_auth_options.documentation

--- a/plugins/modules/kibana_fleet_host.py
+++ b/plugins/modules/kibana_fleet_host.py
@@ -1,0 +1,141 @@
+#!/usr/bin/python
+# Copyright 2021 Expedient
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -*- coding: utf-8 -*-
+
+#from plugins.modules.ece_cluster import DOCUMENTATION
+
+
+ANSIBLE_METADATA = {
+  'metadata_version': '1.1',
+  'status': ['preview'],
+  'supported_by': 'community'
+}
+
+DOCUMENTATION = r'''
+---
+module: kibana_fleet_host
+
+short_description: Add host to kibana fleet
+
+version_added: 2.3.0 # change this
+
+author: Mac Masterson (@mgaruccio)
+
+requirements:
+  - python3
+
+description:
+  - "This module adds a host endpoint to a kibana fleet"
+
+options:
+    host:
+        description:
+            - The Kibana Host you're updating
+        type: str
+    username:
+        description:
+            - Elastic Username
+        type: str
+    password:
+        description:
+            - Elastic Password
+        type: str
+    verify_ssl_cert:
+        description:
+            - Whether or not to verify SSL cert on API requests
+        type: bool
+    url:
+        description:
+            - The url that you want to apply as a fleet server host or an elasticsearch host
+        type: str
+    url_type:
+        description:
+            - The url type that you want to set for the fleet
+            - 'server' sets the fleet server host
+            - 'elasticsearch' sets the fleet elasticsearch host
+        options:
+            - server
+            - elasticsearch
+
+extends_documentation_fragment:
+  - expedient.elastic.elastic_auth_options.documentation
+'''
+
+
+try:
+  from ansible_collections.expedient.elastic.plugins.module_utils.kibana import Kibana
+  import ansible_collections.expedient.elastic.plugins.module_utils.lookups
+except:
+  import sys
+  import os
+  util_path = new_path = f'{os.getcwd()}/plugins/module_utils'
+  sys.path.append(util_path)
+  from kibana import Kibana
+
+from ansible.module_utils.basic import AnsibleModule
+from json import dumps
+
+def main():
+    module_args=dict(
+        host=dict(type='str', required=True),
+        port=dict(type='int', required=True),
+        username=dict(type='str', required=True),
+        password=dict(type='str', required=True, no_log=True),
+        verify_ssl_cert=dict(type='bool', default=True),
+        url_type=dict(type='str', choices=['server', 'elasticsearch'], required=True),
+        url=dict(type='str', required=True),
+    )
+
+    results = {
+        'changed': False,
+        'msg': ''
+        }
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+    kibana_fleet = Kibana(module)
+
+    url = module.params.get('url')
+    url_type = module.params.get('url_type')
+
+    if url_type == 'server':
+        current_fleet_servers = kibana_fleet.get_fleet_server_hosts()
+        if url in current_fleet_servers:
+            results['msg'] += f"\n{url} already exists in the fleet"
+        else:
+            fleet_server_add = kibana_fleet.set_fleet_server_host(url)
+            if 'message' in fleet_server_add:
+                module.fail_json(msg=fleet_server_add['message'])
+            else:
+                results['changed'] = True
+                results['msg'] += f"Successfully set fleet server host to {url}"
+
+    if url_type == 'elasticsearch':
+        current_elasticsearch_hosts = kibana_fleet.get_fleet_elasticsearch_hosts()
+        if url in current_elasticsearch_hosts:
+            results['msg'] += f"\n{url} already exists in the fleet"
+        else:
+            elasticsearch_host_add = kibana_fleet.set_fleet_elasticsearch_host(url)
+            if 'message' in elasticsearch_host_add:
+                module.fail_json(msg=elasticsearch_host_add['message'])
+            else:
+                results['changed'] = True
+                results['msg'] += f"\nSuccessfully set fleet elasticsearch server host to {url}"
+
+    module.exit_json(**results)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/kibana_fleet_host.py
+++ b/plugins/modules/kibana_fleet_host.py
@@ -32,7 +32,7 @@ short_description: Add host to kibana fleet
 
 version_added: 2.3.0 # change this
 
-author: Mac Masterson (@mgaruccio)
+author: Mac Masterson (@maclin-masterson)
 
 requirements:
   - python3

--- a/plugins/modules/kibana_fleet_host.py
+++ b/plugins/modules/kibana_fleet_host.py
@@ -96,7 +96,8 @@ def main():
         password=dict(type='str', required=True, no_log=True),
         verify_ssl_cert=dict(type='bool', default=True),
         url_type=dict(type='str', choices=['fleet_server', 'elasticsearch'], required=True),
-        url=dict(type='str', required=True),
+        urls=dict(type='list', elements='str', required=True),
+        action=dict(type='str', choices=['add', 'overwrite', 'remove'], default='add')
     )
 
     results = {

--- a/plugins/modules/kibana_fleet_host.py
+++ b/plugins/modules/kibana_fleet_host.py
@@ -95,7 +95,7 @@ def main():
         username=dict(type='str', required=True),
         password=dict(type='str', required=True, no_log=True),
         verify_ssl_cert=dict(type='bool', default=True),
-        url_type=dict(type='str', choices=['server', 'elasticsearch'], required=True),
+        url_type=dict(type='str', choices=['fleet_server', 'elasticsearch'], required=True),
         url=dict(type='str', required=True),
     )
 
@@ -110,7 +110,7 @@ def main():
     url = module.params.get('url')
     url_type = module.params.get('url_type')
 
-    if url_type == 'server':
+    if url_type == 'fleet_server':
         current_fleet_servers = kibana_fleet.get_fleet_server_hosts()
         if url in current_fleet_servers:
             results['msg'] += f"\n{url} already exists in the fleet"

--- a/plugins/modules/kibana_fleet_host.py
+++ b/plugins/modules/kibana_fleet_host.py
@@ -88,6 +88,28 @@ except:
 from ansible.module_utils.basic import AnsibleModule
 from json import dumps
 
+class KibanaFleet(Kibana):
+    def __init__(self, module):
+        super().__init__(module)
+        self.url_type = self.module.params.get('url_type')
+
+    def get_current_urls(self):
+        if self.url_type == 'fleet_server':
+            current_urls = self.get_fleet_server_hosts()
+        if self.url_type == 'elasticsearch':
+            current_urls = self.get_fleet_elasticsearch_hosts()
+        return current_urls
+
+    def send_urls(self, urls: list):
+        if self.url_type == 'fleet_server':
+            result = self.set_fleet_server_hosts(urls)
+
+        if self.url_type == 'elasticsearch':
+            result = self.set_fleet_elasticsearch_hosts(urls)
+
+        return result
+
+
 def main():
     module_args=dict(
         host=dict(type='str', required=True),


### PR DESCRIPTION
Adding a new module, kibana_fleet_host, that will allow a user to set server urls and elasticsearch urls for a given kibana fleet.

This required a few additions to module_utils/kibana.py as well.

- adding a headers argument to send_api_request(), so we can pass additional headers. This is needed to update the server url for a fleet.
- Adding get and set functions for fleet server hosts
- Adding get and set functions for fleet elasticsearch hosts