### PR TITLE
Update pkg policies to support 8.3

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-version: 2.3.3
+version: 2.3.4
 namespace: expedient
 name: elastic
 readme: README.md

--- a/plugins/module_utils/kibana.py
+++ b/plugins/module_utils/kibana.py
@@ -413,7 +413,7 @@ class Kibana(object):
             for policy_input in policy_template['inputs']:
               inputs_body_entry = {}
               inputs_body_entry['policy_template'] = policy_template['name']
-              inputs_body_entry['enabled'] = True
+              inputs_body_entry['enabled'] = False
               inputs_body_entry['type'] = policy_input['type']
               if 'config' in policy_input:                 
                 inputs_body_entry['config'] = policy_input['config']
@@ -452,7 +452,6 @@ class Kibana(object):
                   
                 inputs_body_entry['streams'] = inputs_body_streams
               inputs_body.append(inputs_body_entry)
-
     if not pkg_policy_object:
       body = {
         "name": pkg_policy_name,

--- a/plugins/modules/elastic_endpoint_security.py
+++ b/plugins/modules/elastic_endpoint_security.py
@@ -166,9 +166,11 @@ def main():
           pkg_policy_object = kibana.create_pkg_policy(pkg_policy_name, pkg_policy_desc, agent_policy_id, integration_object, namespace)
           updated_pkg_policy_object = kibana.create_securityctrl_baseline_settings(pkg_policy_object)
           results['pkg_policy_status'] = "No Integration Package found, Package Policy created"
+          results['pkg_policy_object'] = pkg_policy_object
           results['changed'] = True
         else:
           results['pkg_policy_status'] = "No Integration Package found, Package Policy not created becans check_mode is set to true"
+          results['pkg_policy_object'] = ""
           results['changed'] = False
         
       results['pkg_policy_object'] = pkg_policy_object

--- a/plugins/modules/elastic_pkgpolicy.py
+++ b/plugins/modules/elastic_pkgpolicy.py
@@ -171,7 +171,7 @@ def main():
           results['pkg_policy_object'] = pkg_policy_object
           results['changed'] = True
         else:
-          results['pkg_policy_status'] = "No Integration Package found, Package Policy not created becans check_mode is set to true"
+          results['pkg_policy_status'] = "No Integration Package found, Package Policy not created because check_mode is set to true"
           results['pkg_policy_object'] = ""
           results['changed'] = False
 

--- a/plugins/modules/elastic_pkgpolicy.py
+++ b/plugins/modules/elastic_pkgpolicy.py
@@ -127,6 +127,7 @@ def main():
         results['changed'] = True
 
     kibana = Kibana(module)
+    
     if module.params.get('agent_policy_id'):
       agency_policy_object = kibana.get_agent_policy_byid(agent_policy_id)
     else:
@@ -164,11 +165,15 @@ def main():
         results['pkg_policy_status'] = "Integration Package found, No package created"
         results['changed'] = False
       else:
-        pkg_policy_object = kibana.create_pkg_policy(pkg_policy_name, pkg_policy_desc, agent_policy_id, integration_object, namespace)
-        results['pkg_policy_status'] = "No Integration Package found, Package Policy created"
-      results['pkg_policy_object'] = pkg_policy_object
-    else:
-      results['pkg_policy_object'] = "A valid state was not passed"
+        if module.check_mode == False: 
+          pkg_policy_object = kibana.create_pkg_policy(pkg_policy_name, pkg_policy_desc, agent_policy_id, integration_object, namespace)
+          results['pkg_policy_status'] = "No Integration Package found, Package Policy created"
+          results['pkg_policy_object'] = pkg_policy_object
+          results['changed'] = True
+        else:
+          results['pkg_policy_status'] = "No Integration Package found, Package Policy not created becans check_mode is set to true"
+          results['pkg_policy_object'] = ""
+          results['changed'] = False
 
     if integration_settings:
       if not 'package' in pkg_policy_object:
@@ -191,7 +196,7 @@ def main():
       '''
       
       pkg_policy_info = kibana.update_pkg_policy(pkg_policy_object_id, pkg_policy_object)
-      results['pkg_policy_object_update'] = pkg_policy_object
+      results['pkg_policy_object_update'] = pkg_policy_info
 
     module.exit_json(**results)
 


### PR DESCRIPTION
Bug Fix
- Update Pkg Policy inputs to default to disabled. The default settings of new versions of a couple of the package policies are invalid so when you try to apply the settings with them disabled an error is generated.
- Fixing some results output to be more consistent and accurate 