### PR TITLE
get_elastic_userpass_if_deploy_exists_when_create

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-version: 2.3.6
+version: 2.3.7
 namespace: expedient
 name: elastic
 readme: README.md

--- a/plugins/module_utils/ece.py
+++ b/plugins/module_utils/ece.py
@@ -365,3 +365,8 @@ class ECE(object):
     if not wait_result:
       self.module.fail_json(msg=f'failed to stop deployment {deployment_id}')
     return stop_result
+
+  def set_elastic_user_password(self, deployment_id, resource_kind = "elasticsearch", ref_id = "main-elasticsearch"):
+    endpoint = f'deployments/{deployment_id}/{resource_kind}/{ref_id}/_reset-password'
+    credentail_object = self.send_api_request(endpoint, 'POST')
+    return credentail_object

--- a/plugins/modules/ece_cluster.py
+++ b/plugins/modules/ece_cluster.py
@@ -296,9 +296,11 @@ def main():
     if matching_clusters:
       results['msg'] = 'cluster exists'
       ## This code handles edge cases poorly, in the interest of being able to match the data format of the cluster creation result
+      elastic_creds = ece_cluster.set_elastic_user_password(matching_clusters['id'])
       results['cluster_data'] = {
         'elasticsearch_cluster_id': matching_clusters['resources']['elasticsearch'][0]['id'],
-        'kibana_cluster_id': matching_clusters['resources']['kibana'][0]['id']
+        'kibana_cluster_id': matching_clusters['resources']['kibana'][0]['id'],
+        'credentials': elastic_creds
       }
       if len( matching_clusters['resources']['apm']) > 0:
         results['cluster_data']['apm_id'] = matching_clusters['resources']['apm'][0]['id']


### PR DESCRIPTION
Add Feature
- Reset elastic user password function available
- If a deployment exists with the same name when trying to create a deployment, the elastic password will be reset and the credentials returned as if newly created.