### PR TITLE
Fix Cloud Endpoint Security to work without Integration Title

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-version: 2.3.14
+version: 2.3.15
 namespace: expedient
 name: elastic
 readme: README.md

--- a/plugins/module_utils/kibana.py
+++ b/plugins/module_utils/kibana.py
@@ -452,15 +452,22 @@ class Kibana(object):
         integration_install = "Cannot proceed with check_mode set to " + self.module.check_mode
       return integration_install
   
-  def check_integration(self, integration_title):
+  def check_integration(self, integration_title = None, integration_name = None, *args, **kwargs):
       integration_objects = self.get_integrations()
       integration_detail_object = None
       for integration in integration_objects['response']:
-        if integration['title'].upper() in integration_title.upper():
-          if integration['status'] != 'installed':
-            integration_install = self.install_integration(integration['name'],integration['version'])
-          integration_detail_object = self.get_integration(integration['name'],integration['version'])
-          break
+        if integration_title:
+          if integration['title'].upper() in integration_title.upper():
+            if integration['status'] != 'installed':
+              integration_install = self.install_integration(integration['name'],integration['version'])
+            integration_detail_object = self.get_integration(integration['name'],integration['version'])
+            break
+        if integration_name:
+          if integration['name'].upper() in integration_name.upper():
+            if integration['status'] != 'installed':
+              integration_install = self.install_integration(integration['name'],integration['version'])
+            integration_detail_object = self.get_integration(integration['name'],integration['version'])
+            break
       return integration_detail_object
   
   def get_integration(self, integration_name, version = None):

--- a/plugins/modules/ece_cluster_logs_and_metrics.py
+++ b/plugins/modules/ece_cluster_logs_and_metrics.py
@@ -1,0 +1,100 @@
+#!/usr/bin/python
+# Copyright 2021 Expedient
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ansible.module_utils.basic import AnsibleModule
+
+try:
+  from ansible_collections.expedient.elastic.plugins.module_utils.ece import ECE
+except:
+  import sys
+  import os
+  util_path = new_path = f'{os.getcwd()}/plugins/module_utils'
+  sys.path.append(util_path)
+  from ece import ECE
+
+import json
+
+results = {}    
+    
+def main():
+
+    module_args=dict(
+        host=dict(type='str',default='elastic-admin.expedient.cloud'),
+        port=dict(type='int', default=12443),
+        username=dict(type='str', required=True),
+        password=dict(type='str', no_log=True, required=True),   
+        verify_ssl_cert=dict(type='bool', default=True),
+        deployment_name=dict(type='str'),
+        deployment_id=dict(type='str', default=None),
+        no_cluster_object=dict(type='bool', default=True),
+        logging_dest=dict(type='str', required=True),
+        metrics_dest=dict(type='str', required=True),
+        logging_ref_id=dict(type='str', default="elasticsearch"),
+        metrics_ref_id=dict(type='str', default="elasticsearch")
+    )
+    argument_dependencies = []
+        #('state', 'present', ('enabled', 'alert_type', 'conditions', 'actions')),
+        #('alert-type', 'metrics_threshold', ('conditions'))
+    
+    module = AnsibleModule(argument_spec=module_args, required_if=argument_dependencies, supports_check_mode=True)
+    
+    deployment_name = module.params.get('deployment_name')
+    deployment_id = module.params.get('deployment_id')
+    logging_dest = module.params.get('logging_dest')
+    metrics_dest = module.params.get('metrics_dest')
+    logging_ref_id = module.params.get('logging_ref_id')
+    metrics_ref_id = module.params.get('metrics_ref_id')
+    results = { 'changed': True }
+        
+    ElasticDeployments = ECE(module)
+    
+    if deployment_id:
+      deployment_object = [ElasticDeployments.get_deployment_byid(deployment_id)]
+    elif deployment_name:
+      deployment_object = [ElasticDeployments.get_deployment_info(deployment_name)]
+      
+    logging_object = [ElasticDeployments.get_deployment_info(logging_dest)]
+    metrics_object = [ElasticDeployments.get_deployment_info(metrics_dest)]
+    
+    if deployment_object:
+      update_body = {
+        'logging': {
+          'destination': {
+            'deployment_id': logging_object[0]['resources'][logging_ref_id][0]['id'],
+            'ref_id': logging_ref_id
+          }
+          },
+        'metrics': {
+          'destination': {
+            'deployment_id': metrics_object[0]['resources'][metrics_ref_id][0]['id'],
+            'ref_id': metrics_ref_id
+          }
+        }
+      }
+
+      body = {
+        'settings': {
+          'observability': update_body
+        },
+        'prune_orphans': False
+      }
+      ElasticDeployments.update_deployment_byid(deployment_object[0]['id'], body)
+    results['changed'] = True
+    module.exit_json(**results)
+
+if __name__ == "__main__":
+    main()
+    
+     

--- a/plugins/modules/elastic_expedient_pkgpolicy.py
+++ b/plugins/modules/elastic_expedient_pkgpolicy.py
@@ -92,7 +92,7 @@ def main():
         verify_ssl_cert=dict(type='bool', default=True),
         agent_policy_id=dict(type='str'),
         agent_policy_name=dict(type='str'),
-        integration_title=dict(type='str', required=True),
+        integration_title=dict(type='str'),
         integration_ver=dict(type='str'),
         integration_name=dict(type='str'),
         pkg_policy_name=dict(type='str', required=True),
@@ -108,7 +108,8 @@ def main():
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True,
                             mutually_exclusive=[('agent_policy_name', 'agent_policy_id')],
                             required_one_of=[('agent_policy_name', 'agent_policy_id')],
-                            required_together=[('integration_ver','integration_name')])
+                            required_together=[('integration_ver','integration_name')]
+                          )
     
     state = module.params.get('state')
     agent_policy_name = module.params.get('agent_policy_name')
@@ -143,7 +144,8 @@ def main():
     
     if ( integration_title and not ( integration_ver and integration_title )):
       integration_object = kibana.check_integration(integration_title)
-    elif ( integration_name and integration_ver and integration_title ) and not integration_object:
+    elif (( integration_name and integration_ver and integration_title ) and not integration_object) or \
+      (( integration_name and integration_ver ) and not integration_object):
       results['integration_status'] = "No integration found, but Integration Name, Version, and Title found"
       integration_object = {
         'name': integration_name,

--- a/plugins/modules/elastic_integration_info.py
+++ b/plugins/modules/elastic_integration_info.py
@@ -34,7 +34,8 @@ def main():
         username=dict(type='str', required=True),
         password=dict(type='str', no_log=True, required=True),   
         verify_ssl_cert=dict(type='bool', default=True),
-        integration_title=dict(type='str', required=True)
+        integration_title=dict(type='str'),
+        integration_name=dict(type='str')
     )
     argument_dependencies = []
         #('state', 'present', ('enabled', 'alert_type', 'conditions', 'actions')),
@@ -45,10 +46,11 @@ def main():
     results['changed'] = False
     
     integration_title = module.params.get('integration_title')
+    integration_name = module.params.get('integration_name')
   
     kibana = Kibana(module)
       
-    integration_object = kibana.check_integration(integration_title)
+    integration_object = kibana.check_integration(integration_title, integration_name)
     
     if not integration_object:
       results['integration_status'] = 'Integration name is not a valid'


### PR DESCRIPTION
Bug Fix:
- Allow integration name to be passed when checking an integration and creating a pkg policy