### PR TITLE
Update Integrations API Endpoints to handle Elastic 8.6

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-version: 2.3.17
+version: 2.3.18
 namespace: expedient
 name: elastic
 readme: README.md

--- a/plugins/modules/elastic_expedient_pkgpolicy.py
+++ b/plugins/modules/elastic_expedient_pkgpolicy.py
@@ -169,7 +169,10 @@ def main():
       body = {
         "keepPoliciesUpToDate": False
       }
-      integration_object = kibana.update_integration(integration_object['name'], body)
+      integration_object = kibana.update_integration(
+          integration_name = integration_object['name'], 
+          integration_version=integration_object['version'], 
+          body = body)
       pkg_policy_object = kibana.get_pkg_policy(pkg_policy_name)
       pkg_policy_object_orig = pkg_policy_object
       applied_defaults = False
@@ -389,7 +392,10 @@ def main():
       body = {
         "keepPoliciesUpToDate": True
       }
-      integration_object = kibana.update_integration(integration_object['name'], body)
+      integration_object = kibana.update_integration(
+          integration_name = integration_object['name'], 
+          integration_version=integration_object['version'], 
+          body = body)
       results['pkg_policy_object_update'] = pkg_policy_info
 
     module.exit_json(**results)


### PR DESCRIPTION
New Features:
- Add major, minor, and patch version variables
- Using major and minor version variables, select appropriate integrations flag to show all integrations.