### PR TITLE
Add index lifecycle policy for deployment

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-version: 2.3.19
+version: 2.3.20
 namespace: expedient
 name: elastic
 readme: README.md

--- a/plugins/module_utils/elastic.py
+++ b/plugins/module_utils/elastic.py
@@ -118,3 +118,15 @@ class Elastic(object):
     }
     role_mapping_object = self.send_api_request(endpoint, data=data, method='POST')
     return role_mapping_object
+  
+  ########### Index Lifecycle Policies
+  
+  def get_index_lifecycle_policy(self, policy_name):
+    endpoint = '_ilm/policy/' + policy_name
+    index_lifecycle_policy = self.send_api_request(endpoint, 'GET')
+    return index_lifecycle_policy
+  
+  def update_index_lifecycle_policy(self, policy_name, index_lifecycle_policy_data):
+    endpoint = '_ilm/policy/' + policy_name
+    index_lifecycle_policy = self.send_api_request(endpoint, 'PUT', data=index_lifecycle_policy_data)
+    return index_lifecycle_policy

--- a/plugins/module_utils/kibana.py
+++ b/plugins/module_utils/kibana.py
@@ -680,6 +680,11 @@ class Kibana(object):
     
 # Elastic Agent Policy functions
 
+  def get_agentpolicy_enrollment_tokens(self, perPage = 500):
+    endpoint  = 'fleet/enrollment_api_keys?perPage='+ str(perPage)
+    enrollment_api_objects = self.send_api_request(endpoint, 'GET')
+    return enrollment_api_objects
+
   def get_all_agent_policys(self, perPage = 500):
     endpoint  = 'fleet/agent_policies?perPage='+ str(perPage)
     agent_policy_objects = self.send_api_request(endpoint, 'GET')

--- a/plugins/modules/elastic_index_lifecycle_policy.py
+++ b/plugins/modules/elastic_index_lifecycle_policy.py
@@ -1,0 +1,68 @@
+#!/usr/bin/python
+# Copyright 2021 Expedient
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ansible.module_utils.basic import _ANSIBLE_ARGS, AnsibleModule
+#from ansible.module_utils.basic import *
+
+try:
+  from ansible_collections.expedient.elastic.plugins.module_utils.elastic import Elastic
+except:
+  import sys
+  import os
+  util_path = new_path = f'{os.getcwd()}/plugins/module_utils'
+  sys.path.append(util_path)
+  from elastic import Elastic
+
+results = {}
+
+def main():
+
+    module_args=dict(   
+        host=dict(type='str',required=True),
+        port=dict(type='int', default=9243),
+        username=dict(type='str', required=True),
+        password=dict(type='str', no_log=True, required=True),   
+        verify_ssl_cert=dict(type='bool', default=True),
+        index_lifecycle_policy_name=dict(type='str'),
+        settings=dict(type='dict'),
+        deployment_info=dict(type='dict', default=None)
+    )
+    argument_dependencies = []
+        #('state', 'present', ('enabled', 'alert_type', 'conditions', 'actions')),
+        #('alert-type', 'metrics_threshold', ('conditions'))
+    
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+
+    results['changed'] = False
+    
+    elastic = Elastic(module)
+    index_lifecycle_policy_name = module.params.get('index_lifecycle_policy_name')
+    new_settings = module.params.get('settings')
+    
+    if index_lifecycle_policy_name and new_settings:
+      results['elastic_index_lifecycle_status'] = "Elastic Index Lifecycle Policy found"
+      elastic_index_lifecycle_policy_object = elastic.update_index_lifecycle_policy(index_lifecycle_policy_name, new_settings)
+      results['index_lifecycle_policy_object'] = elastic_index_lifecycle_policy_object
+      results['changed'] = True
+    else:
+      results['elastic_index_lifecycle_status'] = "Elastic Index Lifecycle Policy NOT found"
+      results['index_lifecycle_policy_object'] = ""
+    
+    module.exit_json(**results)
+
+if __name__ == "__main__":
+    main()
+    
+     

--- a/plugins/modules/elastic_index_lifecycle_policy_info.py
+++ b/plugins/modules/elastic_index_lifecycle_policy_info.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python
+# Copyright 2021 Expedient
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ansible.module_utils.basic import _ANSIBLE_ARGS, AnsibleModule
+#from ansible.module_utils.basic import *
+
+try:
+  from ansible_collections.expedient.elastic.plugins.module_utils.elastic import Elastic
+except:
+  import sys
+  import os
+  util_path = new_path = f'{os.getcwd()}/plugins/module_utils'
+  sys.path.append(util_path)
+  from elastic import Elastic
+
+results = {}
+
+def main():
+
+    module_args=dict(   
+        host=dict(type='str',required=True),
+        port=dict(type='int', default=9243),
+        username=dict(type='str', required=True),
+        password=dict(type='str', no_log=True, required=True),   
+        verify_ssl_cert=dict(type='bool', default=True),
+        index_lifecycle_policy_name=dict(type='str'),
+        #settings=dict(type='dict'),
+        deployment_info=dict(type='dict', default=None)
+    )
+    argument_dependencies = []
+        #('state', 'present', ('enabled', 'alert_type', 'conditions', 'actions')),
+        #('alert-type', 'metrics_threshold', ('conditions'))
+    
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+
+    results['changed'] = False
+    
+    elastic = Elastic(module)
+    index_lifecycle_policy_name = module.params.get('index_lifecycle_policy_name')
+    
+    if index_lifecycle_policy_name:
+      results['elastic_index_lifecycle_status'] = "Elastic Index Lifecycle Policy found"
+      elastic_index_lifecycle_policy_object = elastic.get_index_lifecycle_policy(index_lifecycle_policy_name)
+      results['index_lifecycle_policy_object'] = elastic_index_lifecycle_policy_object
+    else:
+      results['elastic_index_lifecycle_status'] = "Elastic Index Lifecycle Policy NOT found"
+      results['index_lifecycle_policy_object'] = ""
+    
+    module.exit_json(**results)
+
+if __name__ == "__main__":
+    main()
+    
+     


### PR DESCRIPTION
New Features:
- Add code to get Agent Policy Enrollment Tokens
- Add code to get and update index lifecycle policies
- Add code to be called from Ansible to get and update index lifecycle policies