### PR TITLE
add secret reference to exclude

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-version: 2.4.6
+version: 2.4.7
 namespace: expedient
 name: elastic
 readme: README.md

--- a/plugins/module_utils/kibana.py
+++ b/plugins/module_utils/kibana.py
@@ -565,6 +565,8 @@ class Kibana(object):
         body.pop('updated_at')
       if 'updated_by' in body:
         body.pop('updated_by')
+      if 'secret_references' in body:
+        body.pop('secret_references')
       input_no = 0
       for input in body['inputs']:
         if 'streams' in input:


### PR DESCRIPTION
Bug Fix
- Clearly, I didn't test this well enough the first time
- When updating a package policy if there is a password in the payload there will also be a 'secret_references'. In order to apply the json to update the package policy, secret_references must be removed.